### PR TITLE
Show constructed media URLs from pagebuilder HTML

### DIFF
--- a/Model/Resolver/StockistGallery.php
+++ b/Model/Resolver/StockistGallery.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Aligent\Stockists\Model\Resolver;
+
+use Magento\Cms\Model\Template\FilterProvider;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+
+class StockistGallery implements ResolverInterface
+{
+    /**
+     * @var FilterProvider
+     */
+    private FilterProvider $filterProvider;
+
+    /**
+     * StockistGallery constructor.
+     * @param FilterProvider $filterProvider
+     */
+    public function __construct(FilterProvider $filterProvider) {
+        $this->filterProvider = $filterProvider;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null): string
+    {
+        if (!isset($value['model'])) {
+            throw new LocalizedException(__('"model" value should be specified'));
+        }
+
+        /** @var \Aligent\Stockists\Api\Data\StockistInterface $stockist */
+        $stockist = $value['model'];
+        $gallery = $stockist->getGallery();
+
+        return $this->filterProvider->getPageFilter()->filter($gallery);
+    }
+}
+

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -15,7 +15,7 @@ type Stockist @doc(description: "A stockist location entity") {
     identifier: String
     location: Location @resolver(class: "Aligent\\Stockists\\Model\\Resolver\\StockistLocation")
     name: String
-    gallery: String
+    gallery: String @resolver(class: "Aligent\\Stockists\\Model\\Resolver\\StockistGallery")
     url_key: String
     description: String
     allow_store_delivery: Boolean


### PR DESCRIPTION
WYSIWYG directives no longer appear in plain text
media URLs are rendered from directives

This PR is to address the plain text WYSIWYG URL directives, as seen from example HTML below
```
<img class=\"pagebuilder-mobile-hidden\" data-src=\"{{media url=wysiwyg/Kathmandu_homepage_slider_1_7.png}}\" alt=\"\" title=\"\" data-element=\"desktop_image\" data-pb-style=\"FAMHGCG\"><img class=\"pagebuilder-mobile-only\" data-src=\"{{media url=wysiwyg/Kathmandu_homepage_slider_1_7.png}}\" alt=\"\" title=\"\" data-element=\"mobile_image\" data-pb-style=\"SWMIT8F\">
```