### PR TITLE
Handle situations where Gallery information is not set

### DIFF
--- a/Model/Resolver/StockistGallery.php
+++ b/Model/Resolver/StockistGallery.php
@@ -13,7 +13,7 @@ class StockistGallery implements ResolverInterface
     /**
      * @var FilterProvider
      */
-    private FilterProvider $filterProvider;
+    private $filterProvider;
 
     /**
      * StockistGallery constructor.

--- a/Model/Resolver/StockistGallery.php
+++ b/Model/Resolver/StockistGallery.php
@@ -34,7 +34,7 @@ class StockistGallery implements ResolverInterface
 
         /** @var \Aligent\Stockists\Api\Data\StockistInterface $stockist */
         $stockist = $value['model'];
-        $gallery = $stockist->getGallery();
+        $gallery = $stockist->getGallery() ?? '';
 
         return $this->filterProvider->getPageFilter()->filter($gallery);
     }


### PR DESCRIPTION
Even though `$this->filterProvider->getPageFilter()->filter();` should always return a string, it returns null when given null and is causing internal server errors for Kathmandu.

In addition I'm removing a class variable type restriction because this module is meant to support PHP 7.2.