### PR TITLE
Add ability to disable stockists

### DIFF
--- a/Api/Data/StockistInterface.php
+++ b/Api/Data/StockistInterface.php
@@ -12,6 +12,7 @@ interface StockistInterface extends ExtensibleDataInterface
      */
     const STOCKIST_ID = 'stockist_id';
     const IDENTIFIER = 'identifier';
+    const IS_ACTIVE = 'is_active';
     const DESCRIPTION = 'description';
     const URL_KEY = 'url_key';
     const GALLERY = 'gallery';
@@ -51,6 +52,17 @@ interface StockistInterface extends ExtensibleDataInterface
      * @return $this
      */
     public function setIdentifier(string $identifier): StockistInterface;
+
+    /**
+     * @return bool
+     */
+    public function getIsActive(): bool;
+
+    /**
+     * @param bool $isActive
+     * @return $this
+     */
+    public function setIsActive(bool $isActive): StockistInterface;
 
     /**
      * @return string|null

--- a/Model/Resolver/Stockist.php
+++ b/Model/Resolver/Stockist.php
@@ -40,6 +40,9 @@ class Stockist implements ResolverInterface
             } else {
                 throw new GraphQlInputException(__('The provided identifier or url_key is invalid.'));
             }
+            if (!$result->getIsActive()) {
+                throw new GraphQlInputException(__('The provided identifier or url_key is invalid.'));
+            }
             $locationData = $result->getData();
             $locationData['model'] = $result;
             return $locationData;

--- a/Model/Resolver/Stockist.php
+++ b/Model/Resolver/Stockist.php
@@ -10,7 +10,7 @@ use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
 use Magento\Framework\GraphQl\Query\Resolver\Value;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
-use \Aligent\Stockists\Model\Stockist as StockistModel;
+use \Aligent\Stockists\Api\Data\StockistInterface;
 
 class Stockist implements ResolverInterface
 {
@@ -29,15 +29,15 @@ class Stockist implements ResolverInterface
      */
     public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
     {
-        if (!isset($args[StockistModel::IDENTIFIER]) && !isset($args[StockistModel::URL_KEY])) {
+        if (!isset($args[StockistInterface::IDENTIFIER]) && !isset($args[StockistInterface::URL_KEY])) {
             throw new GraphQlInputException(__('Identifier or url_key must be provided.'));
         }
 
         try {
-            if (isset($args[StockistModel::IDENTIFIER])) {
-                $result = $this->stockistRepository->get($args[StockistModel::IDENTIFIER]);
-            } elseif (isset($args[StockistModel::URL_KEY])) {
-                $result = $this->stockistRepository->getByUrlKey($args[StockistModel::URL_KEY]);
+            if (isset($args[StockistInterface::IDENTIFIER])) {
+                $result = $this->stockistRepository->get($args[StockistInterface::IDENTIFIER]);
+            } elseif (isset($args[StockistInterface::URL_KEY])) {
+                $result = $this->stockistRepository->getByUrlKey($args[StockistInterface::URL_KEY]);
             } else {
                 throw new GraphQlInputException(__('The provided identifier or url_key is invalid.'));
             }

--- a/Model/Resolver/Stockist.php
+++ b/Model/Resolver/Stockist.php
@@ -10,6 +10,7 @@ use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
 use Magento\Framework\GraphQl\Query\Resolver\Value;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use \Aligent\Stockists\Model\Stockist as StockistModel;
 
 class Stockist implements ResolverInterface
 {
@@ -28,15 +29,15 @@ class Stockist implements ResolverInterface
      */
     public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
     {
-        if (!isset($args['identifier']) && !isset($args['url_key'])) {
+        if (!isset($args[StockistModel::IDENTIFIER]) && !isset($args[StockistModel::URL_KEY])) {
             throw new GraphQlInputException(__('Identifier or url_key must be provided.'));
         }
 
         try {
-            if (isset($args['identifier'])) {
-                $result = $this->stockistRepository->get($args['identifier']);
-            } elseif (isset($args['url_key'])) {
-                $result = $this->stockistRepository->getByUrlKey($args['url_key']);
+            if (isset($args[StockistModel::IDENTIFIER])) {
+                $result = $this->stockistRepository->get($args[StockistModel::IDENTIFIER]);
+            } elseif (isset($args[StockistModel::URL_KEY])) {
+                $result = $this->stockistRepository->getByUrlKey($args[StockistModel::URL_KEY]);
             } else {
                 throw new GraphQlInputException(__('The provided identifier or url_key is invalid.'));
             }

--- a/Model/Resolver/Stockists.php
+++ b/Model/Resolver/Stockists.php
@@ -2,6 +2,7 @@
 
 namespace Aligent\Stockists\Model\Resolver;
 
+use Aligent\Stockists\Api\Data\StockistInterface;
 use Magento\Framework\Api\FilterBuilder;
 use Magento\Framework\Api\Search\FilterGroupBuilder;
 use Magento\Framework\GraphQl\Config\Element\Field;
@@ -57,7 +58,7 @@ class Stockists implements ResolverInterface
 
         $searchCriteria = $this->createSearchCriteria($args);
 
-        $activeFilter = $this->filterBuilder->setField('is_active')
+        $activeFilter = $this->filterBuilder->setField(StockistInterface::IS_ACTIVE)
             ->setValue((bool) true)
             ->setConditionType('eq')
             ->create();

--- a/Model/Stockist.php
+++ b/Model/Stockist.php
@@ -82,6 +82,23 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
     }
 
     /**
+     * @return bool
+     */
+    public function getIsActive(): bool
+    {
+        return !!$this->getData('is_active');
+    }
+
+    /**
+     * @param bool $isActive
+     * @return StockistInterface
+     */
+    public function setIsActive(bool $isActive): StockistInterface
+    {
+        return $this->setData('is_active', $isActive);
+    }
+
+    /**
      * @return string|null
      */
     public function getGallery(): ?string

--- a/Model/Stockist.php
+++ b/Model/Stockist.php
@@ -42,7 +42,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setStockistId(int $id): StockistInterface
     {
-        $this->setData('stockist_id', $id);
+        $this->setData(StockistInterface::STOCKIST_ID, $id);
         return $this;
     }
 
@@ -51,7 +51,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function getIdentifier(): string
     {
-        return $this->getData('identifier');
+        return $this->getData(StockistInterface::IDENTIFIER);
     }
 
     /**
@@ -60,7 +60,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setIdentifier(string $identifier): StockistInterface
     {
-        $this->setData('identifier', $identifier);
+        $this->setData(StockistInterface::IDENTIFIER, $identifier);
         return $this;
     }
 
@@ -69,7 +69,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function getDescription(): ?string
     {
-        return $this->getData('description');
+        return $this->getData(StockistInterface::DESCRIPTION);
     }
 
     /**
@@ -78,7 +78,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setDescription(string $description): StockistInterface
     {
-        return $this->setData('description', $description);
+        return $this->setData(StockistInterface::DESCRIPTION, $description);
     }
 
     /**
@@ -86,7 +86,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function getIsActive(): bool
     {
-        return !!$this->getData('is_active');
+        return !!$this->getData(StockistInterface::IS_ACTIVE);
     }
 
     /**
@@ -95,7 +95,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setIsActive(bool $isActive): StockistInterface
     {
-        return $this->setData('is_active', $isActive);
+        return $this->setData(StockistInterface::IS_ACTIVE, $isActive);
     }
 
     /**
@@ -103,7 +103,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function getGallery(): ?string
     {
-        return $this->getData('gallery');
+        return $this->getData(StockistInterface::GALLERY);
     }
 
     /**
@@ -112,7 +112,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setGallery(string $gallery): StockistInterface
     {
-        return $this->setData('gallery', $gallery);
+        return $this->setData(StockistInterface::GALLERY, $gallery);
     }
 
     /**
@@ -120,7 +120,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function getUrlKey(): string
     {
-        return $this->getData('url_key');
+        return $this->getData(StockistInterface::URL_KEY);
     }
 
     /**
@@ -129,7 +129,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setUrlKey(string $urlKey): StockistInterface
     {
-        return $this->setData('url_key', $urlKey);
+        return $this->setData(StockistInterface::URL_KEY, $urlKey);
     }
 
     /**
@@ -137,7 +137,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function getLat(): ?float
     {
-        return $this->getData('lat');
+        return $this->getData(StockistInterface::LAT);
     }
 
     /**
@@ -146,7 +146,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setLat(float $lat): StockistInterface
     {
-        $this->setData('lat', $lat);
+        $this->setData(StockistInterface::LAT, $lat);
         return $this;
     }
 
@@ -155,7 +155,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function getLng(): ?float
     {
-        return $this->getData('lng');
+        return $this->getData(StockistInterface::LNG);
     }
 
     /**
@@ -164,7 +164,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setLng(float $lng): StockistInterface
     {
-        $this->setData('lng', $lng);
+        $this->setData(StockistInterface::LNG, $lng);
         return $this;
     }
 
@@ -173,7 +173,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function getName(): ?string
     {
-        return $this->getData('name');
+        return $this->getData(StockistInterface::NAME);
     }
 
     /**
@@ -182,7 +182,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setName(string $name): StockistInterface
     {
-        $this->setData('name', $name);
+        $this->setData(StockistInterface::NAME, $name);
         return $this;
     }
 
@@ -191,7 +191,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function getStreet(): ?string
     {
-        return $this->getData('street');
+        return $this->getData(StockistInterface::STREET);
     }
 
     /**
@@ -200,7 +200,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setStreet(string $street): StockistInterface
     {
-        $this->setData('street', $street);
+        $this->setData(StockistInterface::STREET, $street);
         return $this;
     }
 
@@ -209,7 +209,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function getSuburb(): ?string
     {
-        return $this->getData('suburb');
+        return $this->getData(StockistInterface::SUBURB);
     }
 
     /**
@@ -218,7 +218,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setSuburb(string $suburb): StockistInterface
     {
-        return $this->setData('suburb', $suburb);
+        return $this->setData(StockistInterface::SUBURB, $suburb);
     }
 
     /**
@@ -226,7 +226,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function getCity(): ?string
     {
-        return $this->getData('city');
+        return $this->getData(StockistInterface::CITY);
     }
 
     /**
@@ -235,7 +235,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setCity(string $city): StockistInterface
     {
-        $this->setData('city', $city);
+        $this->setData(StockistInterface::CITY, $city);
         return $this;
     }
 
@@ -244,7 +244,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function getPostcode(): ?string
     {
-        return $this->getData('postcode');
+        return $this->getData(StockistInterface::POSTCODE);
     }
 
     /**
@@ -253,7 +253,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setPostcode(string $postcode): StockistInterface
     {
-        $this->setData('postcode', $postcode);
+        $this->setData(StockistInterface::POSTCODE, $postcode);
         return $this;
     }
 
@@ -262,7 +262,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function getRegion(): ?string
     {
-        return $this->getData('region');
+        return $this->getData(StockistInterface::REGION);
     }
 
     /**
@@ -271,7 +271,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setRegion(string $region): StockistInterface
     {
-        $this->setData('region', $region);
+        $this->setData(StockistInterface::REGION, $region);
         return $this;
     }
 
@@ -280,7 +280,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function getCountry(): ?string
     {
-        return $this->getData('country');
+        return $this->getData(StockistInterface::COUNTRY);
     }
 
     /**
@@ -289,7 +289,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setCountry(string $countryCode): StockistInterface
     {
-        $this->setData('country', $countryCode);
+        $this->setData(StockistInterface::COUNTRY, $countryCode);
         return $this;
     }
 
@@ -298,7 +298,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function getPhone(): ?string
     {
-        return $this->getData('phone');
+        return $this->getData(StockistInterface::PHONE);
     }
 
     /**
@@ -307,7 +307,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setPhone(string $phone): StockistInterface
     {
-        $this->setData('phone', $phone);
+        $this->setData(StockistInterface::PHONE, $phone);
         return $this;
     }
 
@@ -316,7 +316,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function getAllowStoreDelivery(): ?bool
     {
-        return !!$this->getData('allow_store_delivery');
+        return !!$this->getData(StockistInterface::ALLOW_STORE_DELIVERY);
     }
 
     /**
@@ -325,7 +325,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setAllowStoreDelivery(string $allowStoreDelivery): StockistInterface
     {
-        $this->setData('allow_store_delivery', $allowStoreDelivery);
+        $this->setData(StockistInterface::ALLOW_STORE_DELIVERY, $allowStoreDelivery);
         return $this;
     }
 
@@ -334,7 +334,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function getStoreIds(): array
     {
-        return $this->getData('store_ids');
+        return $this->getData(StockistInterface::STORE_IDS);
     }
 
     /**
@@ -343,7 +343,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setStoreIds(array $storeIds): StockistInterface
     {
-        $this->setData('store_ids', $storeIds);
+        $this->setData(StockistInterface::STORE_IDS, $storeIds);
         return $this;
     }
 
@@ -352,7 +352,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function getHours(): ?\Aligent\Stockists\Api\Data\TradingHoursInterface
     {
-        return $this->getData('hours');
+        return $this->getData(StockistInterface::HOURS);
     }
 
     /**
@@ -361,7 +361,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setHours(\Aligent\Stockists\Api\Data\TradingHoursInterface $hours): StockistInterface
     {
-        $this->setData('hours', $hours);
+        $this->setData(StockistInterface::HOURS, $hours);
         return $this;
     }
 

--- a/Model/Stockist.php
+++ b/Model/Stockist.php
@@ -42,8 +42,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setStockistId(int $id): StockistInterface
     {
-        $this->setData(StockistInterface::STOCKIST_ID, $id);
-        return $this;
+        return $this->setData(StockistInterface::STOCKIST_ID, $id);
     }
 
     /**
@@ -60,8 +59,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setIdentifier(string $identifier): StockistInterface
     {
-        $this->setData(StockistInterface::IDENTIFIER, $identifier);
-        return $this;
+        return $this->setData(StockistInterface::IDENTIFIER, $identifier);
     }
 
     /**
@@ -146,8 +144,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setLat(float $lat): StockistInterface
     {
-        $this->setData(StockistInterface::LAT, $lat);
-        return $this;
+        return $this->setData(StockistInterface::LAT, $lat);
     }
 
     /**
@@ -164,8 +161,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setLng(float $lng): StockistInterface
     {
-        $this->setData(StockistInterface::LNG, $lng);
-        return $this;
+        return $this->setData(StockistInterface::LNG, $lng);
     }
 
     /**
@@ -182,8 +178,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setName(string $name): StockistInterface
     {
-        $this->setData(StockistInterface::NAME, $name);
-        return $this;
+        return $this->setData(StockistInterface::NAME, $name);
     }
 
     /**
@@ -200,8 +195,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setStreet(string $street): StockistInterface
     {
-        $this->setData(StockistInterface::STREET, $street);
-        return $this;
+        return $this->setData(StockistInterface::STREET, $street);
     }
 
     /**
@@ -235,8 +229,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setCity(string $city): StockistInterface
     {
-        $this->setData(StockistInterface::CITY, $city);
-        return $this;
+        return $this->setData(StockistInterface::CITY, $city);
     }
 
     /**
@@ -253,8 +246,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setPostcode(string $postcode): StockistInterface
     {
-        $this->setData(StockistInterface::POSTCODE, $postcode);
-        return $this;
+        return $this->setData(StockistInterface::POSTCODE, $postcode);
     }
 
     /**
@@ -271,8 +263,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setRegion(string $region): StockistInterface
     {
-        $this->setData(StockistInterface::REGION, $region);
-        return $this;
+        return $this->setData(StockistInterface::REGION, $region);
     }
 
     /**
@@ -289,8 +280,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setCountry(string $countryCode): StockistInterface
     {
-        $this->setData(StockistInterface::COUNTRY, $countryCode);
-        return $this;
+        return $this->setData(StockistInterface::COUNTRY, $countryCode);
     }
 
     /**
@@ -307,8 +297,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setPhone(string $phone): StockistInterface
     {
-        $this->setData(StockistInterface::PHONE, $phone);
-        return $this;
+        return $this->setData(StockistInterface::PHONE, $phone);
     }
 
     /**
@@ -325,8 +314,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setAllowStoreDelivery(string $allowStoreDelivery): StockistInterface
     {
-        $this->setData(StockistInterface::ALLOW_STORE_DELIVERY, $allowStoreDelivery);
-        return $this;
+        return $this->setData(StockistInterface::ALLOW_STORE_DELIVERY, $allowStoreDelivery);
     }
 
     /**
@@ -343,8 +331,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setStoreIds(array $storeIds): StockistInterface
     {
-        $this->setData(StockistInterface::STORE_IDS, $storeIds);
-        return $this;
+        return $this->setData(StockistInterface::STORE_IDS, $storeIds);
     }
 
     /**
@@ -361,8 +348,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function setHours(\Aligent\Stockists\Api\Data\TradingHoursInterface $hours): StockistInterface
     {
-        $this->setData(StockistInterface::HOURS, $hours);
-        return $this;
+        return $this->setData(StockistInterface::HOURS, $hours);
     }
 
     /**

--- a/Model/Stockist/Hydrator.php
+++ b/Model/Stockist/Hydrator.php
@@ -92,6 +92,12 @@ class Hydrator implements \Magento\Framework\EntityManager\HydratorInterface
         if (empty($data[StockistInterface::STOCKIST_ID])) {
             unset($data[StockistInterface::STOCKIST_ID]);
         }
+        if (isset($data['is_active']) && $data['is_active'] === 'true') {
+            $data['is_active'] = 1;
+        } else {
+            $data['is_active'] = 0;
+        }
+
         if (isset($data['allow_store_delivery']) && $data['allow_store_delivery'] === 'true') {
             $data['allow_store_delivery'] = 1;
         } else {

--- a/Model/Stockist/Hydrator.php
+++ b/Model/Stockist/Hydrator.php
@@ -92,16 +92,16 @@ class Hydrator implements \Magento\Framework\EntityManager\HydratorInterface
         if (empty($data[StockistInterface::STOCKIST_ID])) {
             unset($data[StockistInterface::STOCKIST_ID]);
         }
-        if (isset($data['is_active']) && $data['is_active'] === 'true') {
-            $data['is_active'] = 1;
+        if (isset($data[StockistInterface::IS_ACTIVE]) && $data[StockistInterface::IS_ACTIVE] === 'true') {
+            $data[StockistInterface::IS_ACTIVE] = 1;
         } else {
-            $data['is_active'] = 0;
+            $data[StockistInterface::IS_ACTIVE] = 0;
         }
 
-        if (isset($data['allow_store_delivery']) && $data['allow_store_delivery'] === 'true') {
-            $data['allow_store_delivery'] = 1;
+        if (isset($data[StockistInterface::ALLOW_STORE_DELIVERY]) && $data[StockistInterface::ALLOW_STORE_DELIVERY] === 'true') {
+            $data[StockistInterface::ALLOW_STORE_DELIVERY] = 1;
         } else {
-            $data['allow_store_delivery'] = 0;
+            $data[StockistInterface::ALLOW_STORE_DELIVERY] = 0;
         }
 
         if (empty($data[StockistInterface::COUNTRY]) && !empty($data['country_id'])) {

--- a/Model/StockistRepository.php
+++ b/Model/StockistRepository.php
@@ -18,7 +18,7 @@ use Magento\Framework\Model\AbstractModel;
 class StockistRepository implements StockistRepositoryInterface
 {
     /**
-     * @var \Aligent\Stockists\Model\StockistFactory
+     * @var StockistFactory
      */
     private $stockistFactory;
     /**
@@ -46,9 +46,8 @@ class StockistRepository implements StockistRepositoryInterface
      */
     private $stockistValidation;
 
-
     /**
-     * @param \Aligent\Stockists\Model\StockistFactory $stockistFactory
+     * @param StockistFactory $stockistFactory
      * @param StockistResource $stockistResource
      * @param StockistCollectionFactory $stockistCollectionFactory
      * @param SearchResultsFactory $searchResultsFactory
@@ -81,9 +80,9 @@ class StockistRepository implements StockistRepositoryInterface
      */
     public function get(string $identifier): StockistInterface
     {
-        /** @var \Aligent\Stockists\Model\Stockist $stockist */
+        /** @var Stockist $stockist */
         $stockist = $this->stockistFactory->create();
-        $this->stockistResource->load($stockist, $identifier, 'identifier');
+        $this->stockistResource->load($stockist, $identifier, Stockist::IDENTIFIER);
         if (!$stockist->getId()) {
             throw new NoSuchEntityException(__('Stockist "%1" does not exist', $identifier));
         }
@@ -96,9 +95,9 @@ class StockistRepository implements StockistRepositoryInterface
      */
     public function getByUrlKey(string $urlKey): StockistInterface
     {
-        /** @var \Aligent\Stockists\Model\Stockist $stockist */
+        /** @var Stockist $stockist */
         $stockist = $this->stockistFactory->create();
-        $this->stockistResource->load($stockist, $urlKey, 'url_key');
+        $this->stockistResource->load($stockist, $urlKey, Stockist::URL_KEY);
         if (!$stockist->getId()) {
             throw new NoSuchEntityException(__('Stockist "%1" does not exist', $urlKey));
         }
@@ -158,7 +157,7 @@ class StockistRepository implements StockistRepositoryInterface
      */
     public function getById(int $id): StockistInterface
     {
-        /** @var \Aligent\Stockists\Model\Stockist $stockist */
+        /** @var Stockist $stockist */
         $stockist = $this->stockistFactory->create();
         $this->stockistResource->load($stockist, $id);
         if (!$stockist->getId()) {

--- a/Model/StockistRepository.php
+++ b/Model/StockistRepository.php
@@ -133,6 +133,10 @@ class StockistRepository implements StockistRepositoryInterface
      */
     public function save(StockistInterface $stockist): StockistInterface
     {
+        // New non nullable field which might not be considered in older API
+        if ($stockist->getIsActive() === null) {
+            $stockist->setIsActive(true);
+        }
         $validationResult = $this->stockistValidation->validate($stockist);
 
         if (!$validationResult) {

--- a/Model/StockistValidation.php
+++ b/Model/StockistValidation.php
@@ -43,6 +43,10 @@ class StockistValidation implements StockistValidationInterface
             return false;
         }
 
+        if ($stockist->getIsActive() === null) {
+            $stockist->setIsActive(true);
+        }
+
         $tradingHours = $stockist->getHours();
 
         if ($tradingHours && !is_subclass_of($tradingHours, TradingHoursInterface::class)) {

--- a/Model/StockistValidation.php
+++ b/Model/StockistValidation.php
@@ -48,7 +48,7 @@ class StockistValidation implements StockistValidationInterface
         }
 
         if ($stockist->getIsActive() === null) {
-            $stockist->setIsActive(true);
+            return false;
         }
 
         $tradingHours = $stockist->getHours();

--- a/Model/StockistValidation.php
+++ b/Model/StockistValidation.php
@@ -43,6 +43,10 @@ class StockistValidation implements StockistValidationInterface
             return false;
         }
 
+        if (!$stockist->getUrlKey()) {
+            return false;
+        }
+
         if ($stockist->getIsActive() === null) {
             $stockist->setIsActive(true);
         }

--- a/Ui/DataProvider/Stockist.php
+++ b/Ui/DataProvider/Stockist.php
@@ -74,8 +74,10 @@ class Stockist extends \Magento\Framework\View\Element\UiComponent\DataProvider\
             $item[StockistInterface::HOURS] = $this->json->serialize($item[StockistInterface::HOURS]);
             $item[StockistInterface::STORE_IDS] = \implode(',', $item[StockistInterface::STORE_IDS]);
             $item[StockistInterface::COUNTRY] = $item[StockistInterface::COUNTRY];
-            $item[StockistInterface::ALLOW_STORE_DELIVERY] = isset($item[StockistInterface::ALLOW_STORE_DELIVERY]) && $item[StockistInterface::ALLOW_STORE_DELIVERY] === "1";
-            $item[StockistInterface::IS_ACTIVE] = isset($item[StockistInterface::IS_ACTIVE]) && $item[StockistInterface::IS_ACTIVE] === "1";
+            $item[StockistInterface::ALLOW_STORE_DELIVERY] = isset($item[StockistInterface::ALLOW_STORE_DELIVERY])
+                && $item[StockistInterface::ALLOW_STORE_DELIVERY] === "1";
+            $item[StockistInterface::IS_ACTIVE] = isset($item[StockistInterface::IS_ACTIVE])
+                && $item[StockistInterface::IS_ACTIVE] === "1";
 
         }
         if (self::STOCKIST_FORM_NAME === $this->name) {

--- a/Ui/DataProvider/Stockist.php
+++ b/Ui/DataProvider/Stockist.php
@@ -4,6 +4,7 @@
  */
 namespace Aligent\Stockists\Ui\DataProvider;
 
+use Aligent\Stockists\Api\Data\StockistInterface;
 use Magento\Framework\Serialize\SerializerInterface;
 
 class Stockist extends \Magento\Framework\View\Element\UiComponent\DataProvider\DataProvider
@@ -70,11 +71,11 @@ class Stockist extends \Magento\Framework\View\Element\UiComponent\DataProvider\
         $data = parent::getData();
         foreach ($data['items'] as &$item) {
             // todo: process hours output
-            $item['hours'] = $this->json->serialize($item['hours']);
-            $item['store_ids'] = \implode(',', $item['store_ids']);
-            $item['country_id'] = $item['country'];
-            $item['allow_store_delivery'] = isset($item['allow_store_delivery']) && $item['allow_store_delivery'] === "1";
-            $item['is_active'] = isset($item['is_active']) && $item['is_active'] === "1";
+            $item[StockistInterface::HOURS] = $this->json->serialize($item[StockistInterface::HOURS]);
+            $item[StockistInterface::STORE_IDS] = \implode(',', $item[StockistInterface::STORE_IDS]);
+            $item[StockistInterface::COUNTRY] = $item[StockistInterface::COUNTRY];
+            $item[StockistInterface::ALLOW_STORE_DELIVERY] = isset($item[StockistInterface::ALLOW_STORE_DELIVERY]) && $item[StockistInterface::ALLOW_STORE_DELIVERY] === "1";
+            $item[StockistInterface::IS_ACTIVE] = isset($item[StockistInterface::IS_ACTIVE]) && $item[StockistInterface::IS_ACTIVE] === "1";
 
         }
         if (self::STOCKIST_FORM_NAME === $this->name) {

--- a/Ui/DataProvider/Stockist.php
+++ b/Ui/DataProvider/Stockist.php
@@ -74,6 +74,8 @@ class Stockist extends \Magento\Framework\View\Element\UiComponent\DataProvider\
             $item['store_ids'] = \implode(',', $item['store_ids']);
             $item['country_id'] = $item['country'];
             $item['allow_store_delivery'] = isset($item['allow_store_delivery']) && $item['allow_store_delivery'] === "1";
+            $item['is_active'] = isset($item['is_active']) && $item['is_active'] === "1";
+
         }
         if (self::STOCKIST_FORM_NAME === $this->name) {
             // It is need for support of several fieldsets.

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -4,6 +4,7 @@
     <table name="stockist" resource="default" comment="Stockist locations">
         <column name="stockist_id" xsi:type="int" padding="10" unsigned="true" nullable="false" identity="true" comment="Entity ID"/>
         <column name="identifier" xsi:type="varchar" nullable="false" comment="External identifier" />
+        <column name="is_active" xsi:type="boolean" nullable="false" comment="Store is currently active" default="true"/>
         <column name="url_key" xsi:type="varchar" nullable="false" comment="Url Key"/>
         <column name="lat" xsi:type="decimal" scale="6" precision="9" nullable="true" comment="Latitude" />
         <column name="lng" xsi:type="decimal" scale="6" precision="9" nullable="true" comment="Longitude" />

--- a/view/adminhtml/ui_component/stockist_form.xml
+++ b/view/adminhtml/ui_component/stockist_form.xml
@@ -281,7 +281,7 @@
                     <item name="label" xsi:type="string" translate="true">Allow Store Delivery</item>
                     <item name="formElement" xsi:type="string">checkbox</item>
                     <item name="prefer" xsi:type="string">toggle</item>
-                    <item name="source" xsi:type="string">page</item>
+                    <item name="source" xsi:type="string">allow_store_delivery</item>
                     <item name="sortOrder" xsi:type="number">10</item>
                     <item name="dataScope" xsi:type="string">allow_store_delivery</item>
                     <item name="valueMap" xsi:type="array">

--- a/view/adminhtml/ui_component/stockist_form.xml
+++ b/view/adminhtml/ui_component/stockist_form.xml
@@ -55,6 +55,28 @@
                 <visible>false</visible>
             </settings>
         </field>
+        <field name="is_active">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="visible" xsi:type="boolean">true</item>
+                    <item name="dataType" xsi:type="string">boolean</item>
+                    <item name="label" xsi:type="string" translate="true">Is Active</item>
+                    <item name="formElement" xsi:type="string">checkbox</item>
+                    <item name="prefer" xsi:type="string">toggle</item>
+                    <item name="source" xsi:type="string">is_active</item>
+                    <item name="sortOrder" xsi:type="number">15</item>
+                    <item name="dataScope" xsi:type="string">is_active</item>
+                    <item name="valueMap" xsi:type="array">
+                        <item name="true" xsi:type="boolean">1</item>
+                        <item name="false" xsi:type="boolean">0</item>
+                    </item>
+                    <item name="validation" xsi:type="array">
+                        <item name="required-entry" xsi:type="boolean">true</item>
+                    </item>
+                    <item name="default" xsi:type="boolean">1</item>
+                </item>
+            </argument>
+        </field>
         <field name="identifier" formElement="input" sortOrder="20">
             <settings>
                 <validation>

--- a/view/adminhtml/ui_component/stockist_listing.xml
+++ b/view/adminhtml/ui_component/stockist_listing.xml
@@ -44,7 +44,7 @@
         </settings>
         <bookmark name="bookmarks"/>
         <columnsControls name="columns_controls"/>
-        <filterSearch name="fulltext"/>
+        <filterSearch name="name"/>
         <filters name="listing_filters" />
         <massaction name="listing_massaction" component="Magento_Ui/js/grid/tree-massactions">
             <action name="delete">


### PR DESCRIPTION
Adds the ability to disable stockists in the admin area, and have the `stockist` and `stockists` resolvers not return disabled stockists. Along with other various improvements, most notably fixing the admin search functionality.

This has been tested within a local project.