### PR TITLE
Resolve naming conflicts between country and country_id

### DIFF
--- a/Model/Stockist/Hydrator.php
+++ b/Model/Stockist/Hydrator.php
@@ -104,9 +104,9 @@ class Hydrator implements \Magento\Framework\EntityManager\HydratorInterface
             $data[StockistInterface::ALLOW_STORE_DELIVERY] = 0;
         }
 
-        if (empty($data[StockistInterface::COUNTRY]) && !empty($data['country_id'])) {
+        if (empty($data[StockistInterface::COUNTRY]) && !empty($data[StockistInterface::COUNTRY])) {
             // possible todo: convert to full name?
-            $data[StockistInterface::COUNTRY] = $data['country_id'];
+            $data[StockistInterface::COUNTRY] = $data[StockistInterface::COUNTRY];
         }
 
         foreach ($this->dataProcessors as $dataProcessor) {

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,1 +1,35 @@
+# RELEASE NOTES
+
+## v1.2.6
+
+Add ability to disable stockists
+
+## v1.2.5.3
+
+Handle empty gallery entries
+
+## v1.2.5.2
+
+Filter HTML output of gallery entries
+
+## v1.2.5.1
+
+Fix address data empty in GraphQL
+
+## v1.2.5.0
+
+Add new attributes to Stockists
+
+- Description
+- URL Key
+- Gallery
+- Allow store delivery
+- Suburb
+
+## v1.2.4.2
+
+Fix opening hours not updating
+
+## 1.2.4.0
+
 The first open source release of the M2 stockists module.

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Aligent_Stockists" setup_version="1.2.4">
+    <module name="Aligent_Stockists" setup_version="1.2.6">
         <sequence>
             <module name="Magento_Store" />
             <module name="Magento_GraphQl" />

--- a/view/adminhtml/ui_component/stockist_form.xml
+++ b/view/adminhtml/ui_component/stockist_form.xml
@@ -180,7 +180,7 @@
             <opened>true</opened>
             <dataScope>general</dataScope>
         </settings>
-        <field name="country_id" formElement="select" sortOrder="10">
+        <field name="country" formElement="select" sortOrder="10">
             <settings>
                 <dataType>text</dataType>
                 <label translate="true">Country</label>
@@ -205,8 +205,8 @@
                 <select>
                     <settings>
                         <filterBy>
-                            <field>country_id</field>
-                            <target>${ $.provider }:${ $.parentScope }.country_id</target>
+                            <field>country</field>
+                            <target>${ $.provider }:${ $.parentScope }.country</target>
                         </filterBy>
                         <customEntry>region</customEntry>
                         <options class="Magento\Directory\Model\ResourceModel\Region\Collection"/>


### PR DESCRIPTION
During the changes of using the interface's defined names I discovered a naming conflict between `country_id` in the API and XML and the DB column, so I've cleaned this up