### PR TITLE
Improve country, region, and trading hour changes

### DIFF
--- a/Api/Data/StockistInterface.php
+++ b/Api/Data/StockistInterface.php
@@ -25,6 +25,7 @@ interface StockistInterface extends ExtensibleDataInterface
     const SUBURB = 'suburb';
     const POSTCODE = 'postcode';
     const REGION = 'region';
+    const REGION_ID = 'region_id';
     const COUNTRY = 'country';
     const COUNTRY_ID = 'country_id';
     const PHONE = 'phone';

--- a/Api/Data/StockistInterface.php
+++ b/Api/Data/StockistInterface.php
@@ -26,6 +26,7 @@ interface StockistInterface extends ExtensibleDataInterface
     const POSTCODE = 'postcode';
     const REGION = 'region';
     const COUNTRY = 'country';
+    const COUNTRY_ID = 'country_id';
     const PHONE = 'phone';
     const HOURS = 'hours';
     const STORE_IDS = 'store_ids';

--- a/Model/Stockist/Hydrator.php
+++ b/Model/Stockist/Hydrator.php
@@ -128,9 +128,13 @@ class Hydrator implements \Magento\Framework\EntityManager\HydratorInterface
         }
 
         if (isset($data[StockistInterface::REGION_ID])) {
-            $region = $this->regionFactory->create();
-            $this->regionResource->load($region, $data[StockistInterface::REGION_ID], 'region_id');
-            $data[StockistInterface::REGION] = $region->getName();
+            if (!$data[StockistInterface::REGION_ID]) {
+                $data[StockistInterface::REGION] = "";
+            } else {
+                $region = $this->regionFactory->create();
+                $this->regionResource->load($region, $data[StockistInterface::REGION_ID], 'region_id');
+                $data[StockistInterface::REGION] = $region->getName();
+            }
         }
 
         foreach ($this->dataProcessors as $dataProcessor) {

--- a/Model/Stockist/Hydrator.php
+++ b/Model/Stockist/Hydrator.php
@@ -8,6 +8,7 @@ namespace Aligent\Stockists\Model\Stockist;
 
 use Aligent\Stockists\Api\Data\StockistDataProcessorInterface;
 use Aligent\Stockists\Api\Data\StockistInterface;
+use Magento\Directory\Model\RegionFactory;
 use Magento\Framework\Api\DataObjectHelper;
 use Magento\Framework\EntityManager\MapperPool;
 use Magento\Framework\EntityManager\TypeResolver;
@@ -47,24 +48,32 @@ class Hydrator implements \Magento\Framework\EntityManager\HydratorInterface
     protected $dataObjectProcessor;
 
     /**
+     * @var RegionFactory
+     */
+    protected $regionFactory;
+
+    /**
      * StockistHydrator constructor.
      * @param DataObjectProcessor $dataObjectProcessor
      * @param MapperPool $mapperPool
      * @param TypeResolver $typeResolver
      * @param DataObjectHelper $dataObjectHelper
      * @param StockistDataProcessorInterface[] $dataProcessors
+     * @param RegionFactory $regionFactory
      */
     public function __construct(
         DataObjectProcessor $dataObjectProcessor,
         MapperPool $mapperPool,
         TypeResolver $typeResolver,
         DataObjectHelper $dataObjectHelper,
+        RegionFactory $regionFactory,
         array $dataProcessors = []
     ) {
         $this->dataObjectProcessor = $dataObjectProcessor;
         $this->typeResolver = $typeResolver;
         $this->mapperPool = $mapperPool;
         $this->dataObjectHelper = $dataObjectHelper;
+        $this->regionFactory = $regionFactory;
         $this->dataProcessors = $dataProcessors;
     }
 
@@ -107,6 +116,11 @@ class Hydrator implements \Magento\Framework\EntityManager\HydratorInterface
         if (empty($data[StockistInterface::COUNTRY]) && !empty($data[StockistInterface::COUNTRY_ID])) {
             // possible todo: convert to full name?
             $data[StockistInterface::COUNTRY] = $data[StockistInterface::COUNTRY_ID];
+        }
+
+        if (isset($data[StockistInterface::REGION_ID])) {
+            $region = $this->regionFactory->create()->load($data[StockistInterface::REGION_ID]);
+            $data[StockistInterface::REGION] = $region->getName();
         }
 
         foreach ($this->dataProcessors as $dataProcessor) {

--- a/Model/Stockist/Hydrator.php
+++ b/Model/Stockist/Hydrator.php
@@ -104,9 +104,9 @@ class Hydrator implements \Magento\Framework\EntityManager\HydratorInterface
             $data[StockistInterface::ALLOW_STORE_DELIVERY] = 0;
         }
 
-        if (empty($data[StockistInterface::COUNTRY]) && !empty($data[StockistInterface::COUNTRY])) {
+        if (empty($data[StockistInterface::COUNTRY]) && !empty($data[StockistInterface::COUNTRY_ID])) {
             // possible todo: convert to full name?
-            $data[StockistInterface::COUNTRY] = $data[StockistInterface::COUNTRY];
+            $data[StockistInterface::COUNTRY] = $data[StockistInterface::COUNTRY_ID];
         }
 
         foreach ($this->dataProcessors as $dataProcessor) {

--- a/Model/Stockist/Hydrator.php
+++ b/Model/Stockist/Hydrator.php
@@ -9,6 +9,7 @@ namespace Aligent\Stockists\Model\Stockist;
 use Aligent\Stockists\Api\Data\StockistDataProcessorInterface;
 use Aligent\Stockists\Api\Data\StockistInterface;
 use Magento\Directory\Model\RegionFactory;
+use Magento\Directory\Model\ResourceModel\Region;
 use Magento\Framework\Api\DataObjectHelper;
 use Magento\Framework\EntityManager\MapperPool;
 use Magento\Framework\EntityManager\TypeResolver;
@@ -53,6 +54,11 @@ class Hydrator implements \Magento\Framework\EntityManager\HydratorInterface
     protected $regionFactory;
 
     /**
+     * @var Region
+     */
+    protected $regionResource;
+
+    /**
      * StockistHydrator constructor.
      * @param DataObjectProcessor $dataObjectProcessor
      * @param MapperPool $mapperPool
@@ -60,6 +66,7 @@ class Hydrator implements \Magento\Framework\EntityManager\HydratorInterface
      * @param DataObjectHelper $dataObjectHelper
      * @param StockistDataProcessorInterface[] $dataProcessors
      * @param RegionFactory $regionFactory
+     * @param Region $regionResource
      */
     public function __construct(
         DataObjectProcessor $dataObjectProcessor,
@@ -67,6 +74,7 @@ class Hydrator implements \Magento\Framework\EntityManager\HydratorInterface
         TypeResolver $typeResolver,
         DataObjectHelper $dataObjectHelper,
         RegionFactory $regionFactory,
+        Region $regionResource,
         array $dataProcessors = []
     ) {
         $this->dataObjectProcessor = $dataObjectProcessor;
@@ -74,6 +82,7 @@ class Hydrator implements \Magento\Framework\EntityManager\HydratorInterface
         $this->mapperPool = $mapperPool;
         $this->dataObjectHelper = $dataObjectHelper;
         $this->regionFactory = $regionFactory;
+        $this->regionResource = $regionResource;
         $this->dataProcessors = $dataProcessors;
     }
 
@@ -119,7 +128,8 @@ class Hydrator implements \Magento\Framework\EntityManager\HydratorInterface
         }
 
         if (isset($data[StockistInterface::REGION_ID])) {
-            $region = $this->regionFactory->create()->load($data[StockistInterface::REGION_ID]);
+            $region = $this->regionFactory->create();
+            $this->regionResource->load($region, $data[StockistInterface::REGION_ID], 'region_id');
             $data[StockistInterface::REGION] = $region->getName();
         }
 

--- a/Model/Stockist/Hydrator.php
+++ b/Model/Stockist/Hydrator.php
@@ -122,7 +122,7 @@ class Hydrator implements \Magento\Framework\EntityManager\HydratorInterface
             $data[StockistInterface::ALLOW_STORE_DELIVERY] = 0;
         }
 
-        if (empty($data[StockistInterface::COUNTRY]) && !empty($data[StockistInterface::COUNTRY_ID])) {
+        if (isset($data[StockistInterface::COUNTRY_ID])) {
             // possible todo: convert to full name?
             $data[StockistInterface::COUNTRY] = $data[StockistInterface::COUNTRY_ID];
         }

--- a/Model/TradingHours.php
+++ b/Model/TradingHours.php
@@ -4,9 +4,24 @@ namespace Aligent\Stockists\Model;
 
 use Aligent\Stockists\Api\Data\TradingHoursInterface;
 use Magento\Framework\DataObject;
+use Magento\Framework\Serialize\SerializerInterface;
 
 class TradingHours extends DataObject implements TradingHoursInterface
 {
+    /**
+     * @var SerializerInterface
+     */
+    private $json;
+
+    /**
+     * TradingHours constructor.
+     * @param SerializerInterface $json
+     */
+    public function __construct(
+        SerializerInterface $json
+    ) {
+        $this->json = $json;
+    }
     /**
      * @return string
      */
@@ -65,7 +80,9 @@ class TradingHours extends DataObject implements TradingHoursInterface
 
     public function getPublicHolidays(): ?string
     {
-        return $this->getData('public_holidays') ?: '';
+        $publicHolidaysData = $this->getData('public_holidays') ?: '';
+
+        return $this->json->serialize($publicHolidaysData);
     }
 
     /**

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,12 @@
 # RELEASE NOTES
 
+## v1.2.7
+
+Fix minor bug in region update, and save full name of region to database
+Fix bug where country wouldn't save on change, only on initial creation
+Fix bug where trading hours json would double serialize public holiday data
+Code cleanup
+
 ## v1.2.6
 
 Add ability to disable stockists

--- a/Ui/DataProvider/Stockist.php
+++ b/Ui/DataProvider/Stockist.php
@@ -5,6 +5,7 @@
 namespace Aligent\Stockists\Ui\DataProvider;
 
 use Aligent\Stockists\Api\Data\StockistInterface;
+use Magento\Directory\Model\RegionFactory;
 use Magento\Framework\Serialize\SerializerInterface;
 
 class Stockist extends \Magento\Framework\View\Element\UiComponent\DataProvider\DataProvider
@@ -33,6 +34,11 @@ class Stockist extends \Magento\Framework\View\Element\UiComponent\DataProvider\
      */
     private $json;
 
+    /**
+     * @var RegionFactory
+     */
+    protected $regionFactory;
+
     public function __construct(
         \Aligent\Stockists\Ui\DataProvider\SearchResultFactory $searchResultFactory,
         \Aligent\Stockists\Api\StockistRepositoryInterface $stockistRepository,
@@ -45,6 +51,7 @@ class Stockist extends \Magento\Framework\View\Element\UiComponent\DataProvider\
         \Magento\Framework\App\RequestInterface $request,
         SerializerInterface $json,
         \Magento\Framework\Api\FilterBuilder $filterBuilder,
+        RegionFactory $regionFactory,
         array $meta = [],
         array $data = []
     ) {
@@ -63,6 +70,7 @@ class Stockist extends \Magento\Framework\View\Element\UiComponent\DataProvider\
         $this->json = $json;
         $this->stockistRepository = $stockistRepository;
         $this->searchResultFactory = $searchResultFactory;
+        $this->regionFactory = $regionFactory;
     }
 
 
@@ -74,6 +82,10 @@ class Stockist extends \Magento\Framework\View\Element\UiComponent\DataProvider\
             $item[StockistInterface::HOURS] = $this->json->serialize($item[StockistInterface::HOURS]);
             $item[StockistInterface::STORE_IDS] = \implode(',', $item[StockistInterface::STORE_IDS]);
             $item[StockistInterface::COUNTRY_ID] = $item[StockistInterface::COUNTRY];
+            $item[StockistInterface::REGION_ID] = $this->regionFactory->create()->loadByName(
+                $item[StockistInterface::REGION],
+                $item[StockistInterface::COUNTRY_ID],
+            )->getRegionId();
             $item[StockistInterface::ALLOW_STORE_DELIVERY] = isset($item[StockistInterface::ALLOW_STORE_DELIVERY])
                 && $item[StockistInterface::ALLOW_STORE_DELIVERY] === "1";
             $item[StockistInterface::IS_ACTIVE] = isset($item[StockistInterface::IS_ACTIVE])

--- a/Ui/DataProvider/Stockist.php
+++ b/Ui/DataProvider/Stockist.php
@@ -79,6 +79,7 @@ class Stockist extends \Magento\Framework\View\Element\UiComponent\DataProvider\
         $data = parent::getData();
         foreach ($data['items'] as &$item) {
             // todo: process hours output
+            $item[StockistInterface::HOURS]['public_holidays'] = $this->json->unserialize($item[StockistInterface::HOURS]['public_holidays']);
             $item[StockistInterface::HOURS] = $this->json->serialize($item[StockistInterface::HOURS]);
             $item[StockistInterface::STORE_IDS] = \implode(',', $item[StockistInterface::STORE_IDS]);
             $item[StockistInterface::COUNTRY_ID] = $item[StockistInterface::COUNTRY];

--- a/Ui/DataProvider/Stockist.php
+++ b/Ui/DataProvider/Stockist.php
@@ -73,7 +73,7 @@ class Stockist extends \Magento\Framework\View\Element\UiComponent\DataProvider\
             // todo: process hours output
             $item[StockistInterface::HOURS] = $this->json->serialize($item[StockistInterface::HOURS]);
             $item[StockistInterface::STORE_IDS] = \implode(',', $item[StockistInterface::STORE_IDS]);
-            $item[StockistInterface::COUNTRY] = $item[StockistInterface::COUNTRY];
+            $item[StockistInterface::COUNTRY_ID] = $item[StockistInterface::COUNTRY];
             $item[StockistInterface::ALLOW_STORE_DELIVERY] = isset($item[StockistInterface::ALLOW_STORE_DELIVERY])
                 && $item[StockistInterface::ALLOW_STORE_DELIVERY] === "1";
             $item[StockistInterface::IS_ACTIVE] = isset($item[StockistInterface::IS_ACTIVE])

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -11,7 +11,8 @@ type Query {
 }
 
 type Stockist @doc(description: "A stockist location entity") {
-    id: Int
+    id: Int @doc(description: "Deprecated, use stockist_id")
+    stockist_id: Int
     identifier: String
     location: Location @resolver(class: "Aligent\\Stockists\\Model\\Resolver\\StockistLocation")
     name: String

--- a/view/adminhtml/ui_component/stockist_form.xml
+++ b/view/adminhtml/ui_component/stockist_form.xml
@@ -315,7 +315,7 @@
                         "friday":"08:00 AM to 09:30 PM",
                         "saturday":"08:00 AM to 05:30 PM",
                         "sunday":"08:00 AM to 05:30 PM",
-                            "PublicHolidays": {
+                        "public_holidays": {
                                 "02-02-2021":"08:00 AM to 05:30 PM",
                                 "04-02-2021":"08:00 AM to 05:30 PM"
                             }

--- a/view/adminhtml/ui_component/stockist_form.xml
+++ b/view/adminhtml/ui_component/stockist_form.xml
@@ -180,7 +180,7 @@
             <opened>true</opened>
             <dataScope>general</dataScope>
         </settings>
-        <field name="country" formElement="select" sortOrder="10">
+        <field name="country_id" formElement="select" sortOrder="10">
             <settings>
                 <dataType>text</dataType>
                 <label translate="true">Country</label>
@@ -205,8 +205,8 @@
                 <select>
                     <settings>
                         <filterBy>
-                            <field>country</field>
-                            <target>${ $.provider }:${ $.parentScope }.country</target>
+                            <field>country_id</field>
+                            <target>${ $.provider }:${ $.parentScope }.country_id</target>
                         </filterBy>
                         <customEntry>region</customEntry>
                         <options class="Magento\Directory\Model\ResourceModel\Region\Collection"/>

--- a/view/adminhtml/ui_component/stockist_form.xml
+++ b/view/adminhtml/ui_component/stockist_form.xml
@@ -196,7 +196,7 @@
                 </select>
             </formElements>
         </field>
-        <field name="region" component="Magento_Customer/js/form/element/region" formElement="select">
+        <field name="region_id" component="Magento_Customer/js/form/element/region" formElement="select">
             <settings>
                 <dataType>text</dataType>
                 <label translate="true">State/Province</label>


### PR DESCRIPTION
At the moment the region_id is saved to the region field, instead of the full region name like `'South Australia'`, this PR allows the DB entry and hence graphql queries to return a nice name instead of a meaningless ID.

Also fixes a bug where the `'State/Province'` field shows as a text input all the time instead of when the selected country requires a region to be selected  ...  It does not auto populate the region on first load of the page, but it does force the user to select a region when they switch the country away from Australia and back to Australia.