### PR TITLE
Copy extension attributes onto the returned item within the DataProvider

### DIFF
--- a/Api/Data/StockistInterface.php
+++ b/Api/Data/StockistInterface.php
@@ -31,6 +31,7 @@ interface StockistInterface extends ExtensibleDataInterface
     const PHONE = 'phone';
     const HOURS = 'hours';
     const STORE_IDS = 'store_ids';
+    const EXTENSION_ATTRIBUTES = 'extension_attributes';
 
 
     /**

--- a/Ui/DataProvider/Stockist.php
+++ b/Ui/DataProvider/Stockist.php
@@ -74,7 +74,6 @@ class Stockist extends \Magento\Framework\View\Element\UiComponent\DataProvider\
         $this->regionFactory = $regionFactory;
     }
 
-
     public function getData()
     {
         $data = parent::getData();
@@ -95,6 +94,11 @@ class Stockist extends \Magento\Framework\View\Element\UiComponent\DataProvider\
             $item[StockistInterface::IS_ACTIVE] = isset($item[StockistInterface::IS_ACTIVE])
                 && $item[StockistInterface::IS_ACTIVE] === "1";
 
+            // Make sure extension attributes are copied onto the item itself, then we can
+            // reference them in Ui Components
+            if (isset($item[StockistInterface::EXTENSION_ATTRIBUTES])) {
+                $item = array_merge($item, $item[StockistInterface::EXTENSION_ATTRIBUTES])
+            }
         }
         if (self::STOCKIST_FORM_NAME === $this->name) {
             // It is need for support of several fieldsets.

--- a/Ui/DataProvider/Stockist.php
+++ b/Ui/DataProvider/Stockist.php
@@ -97,7 +97,7 @@ class Stockist extends \Magento\Framework\View\Element\UiComponent\DataProvider\
             // Make sure extension attributes are copied onto the item itself, then we can
             // reference them in Ui Components
             if (isset($item[StockistInterface::EXTENSION_ATTRIBUTES])) {
-                $item = array_merge($item, $item[StockistInterface::EXTENSION_ATTRIBUTES])
+                $item = array_merge($item, $item[StockistInterface::EXTENSION_ATTRIBUTES]);
             }
         }
         if (self::STOCKIST_FORM_NAME === $this->name) {


### PR DESCRIPTION
Essentially this makes sure that the extension attributes are present on the item itself, then we can reference them in Ui Components.