### PR TITLE
Make the lat, long and radius query arguments required

### DIFF
--- a/Model/Resolver/Stockists.php
+++ b/Model/Resolver/Stockists.php
@@ -118,7 +118,7 @@ class Stockists implements ResolverInterface
             throw new GraphQlInputException(__('Location request is invalid.'));
         }
 
-        if (!isset($args['location']['lat']) || !isset($args['location']['lng'])) {
+        if (!isset($args['location']['lat']) || !isset($args['location']['lng']) || !isset($args['location']['radius'])) {
             throw new GraphQlInputException(__('Invalid search coordinates provided.'));
         }
     }

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -65,9 +65,9 @@ type Stockists @doc(description: "Result of a stockist search query") {
 }
 
 input LocationRequest @doc(description: "Request location (origin point and search radius)") {
-    lat: Float @doc(description: "Latitude")
-    lng: Float @doc(description: "Longitude")
+    lat: Float! @doc(description: "Latitude")
+    lng: Float! @doc(description: "Longitude")
     postcode: String @doc(description: "Postcode")
-    radius: Float @doc(description: "Search radius")
+    radius: Float! @doc(description: "Search radius")
     unit: DistanceUnitsEnum @doc(description: "Units of search radius")
 }


### PR DESCRIPTION
Specifically the 'radius' argument was not validated and so it would
result in an internal server error rather than provide a validation
message