### PR TITLE
Fix/15 geocoding response status

### DIFF
--- a/Model/GoogleMapsAdapter.php
+++ b/Model/GoogleMapsAdapter.php
@@ -104,7 +104,7 @@ class GoogleMapsAdapter implements AdapterInterface
         $response = $this->serialiser->unserialize($httpClient->getBody());
 
         /**
-         * Google Maps API return 200 and state any errors that occur as part
+         * Google Maps API returns status and state any errors that occur as part
          * of the api response body...
          *
          * @see: https://developers.google.com/maps/documentation/geocoding/overview#StatusCodes

--- a/Model/GoogleMapsAdapter.php
+++ b/Model/GoogleMapsAdapter.php
@@ -15,7 +15,6 @@ class GoogleMapsAdapter implements AdapterInterface
     const PATH= 'https://maps.googleapis.com/maps/api/geocode/';
 
     const OUTPUT_FORMAT = 'json';
-    const STATUS_CODE_200 = 200;
 
     /**
      * @var CurlFactory
@@ -110,7 +109,7 @@ class GoogleMapsAdapter implements AdapterInterface
          *
          * @see: https://developers.google.com/maps/documentation/geocoding/overview#StatusCodes
          */
-        if ($response['status'] !== self::STATUS_CODE_200) {
+        if ($response['status'] !== GoogleMapsGeocodeResult::STATUS_CODE_OK) {
             return [];
         }
 

--- a/Model/GoogleMapsGeocodeResult.php
+++ b/Model/GoogleMapsGeocodeResult.php
@@ -7,6 +7,8 @@ use Aligent\Stockists\Api\GeocodeResultInterface;
 
 class GoogleMapsGeocodeResult implements GeocodeResultInterface
 {
+    const STATUS_CODE_OK = "OK";
+
     private $status;
     private $lat;
     private $lng;
@@ -26,7 +28,7 @@ class GoogleMapsGeocodeResult implements GeocodeResultInterface
      */
     public function getStatus(): string
     {
-        return $this->status;
+        return (string)$this->status;
     }
 
     /**
@@ -34,7 +36,7 @@ class GoogleMapsGeocodeResult implements GeocodeResultInterface
      */
     public function wasSuccessful() : bool
     {
-        return $this->getStatus() == "OK";
+        return $this->getStatus() === self::STATUS_CODE_OK;
     }
 
     /**
@@ -42,7 +44,7 @@ class GoogleMapsGeocodeResult implements GeocodeResultInterface
      */
     public function getLat(): float
     {
-        return $this->lat;
+        return (float)$this->lat;
     }
 
     /**
@@ -50,6 +52,6 @@ class GoogleMapsGeocodeResult implements GeocodeResultInterface
      */
     public function getLng(): float
     {
-        return $this->lng;
+        return (float)$this->lng;
     }
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,7 +22,7 @@ Better handling of null/empty trading hours values.
  - Fix minor bug in region update, and save full name of region to database
  - Fix bug where country wouldn't save on change, only on initial creation
  - Fix bug where trading hours json would double serialize public holiday data
-Code cleanup
+ - Code cleanup
 
 ## v1.2.6
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,15 @@
 # RELEASE NOTES
+## v2.0.1
+Fix validation of Google geocoding response
+
+## v2.0.0
+ - Remove support for PHP 7.2, add support for PHP 8
+ - Remove attributes not supported by other functionality
+    - Suburb
+    - Gallery
+    - Allow Store Delivery
+ - Code standards fixes
+ - Add schema whitelist
 
 ## v1.2.9
 Copy extension attributes onto the returned item within the DataProvider
@@ -8,9 +19,9 @@ Better handling of null/empty trading hours values.
 
 ## v1.2.7
 
-Fix minor bug in region update, and save full name of region to database
-Fix bug where country wouldn't save on change, only on initial creation
-Fix bug where trading hours json would double serialize public holiday data
+ - Fix minor bug in region update, and save full name of region to database
+ - Fix bug where country wouldn't save on change, only on initial creation
+ - Fix bug where trading hours json would double serialize public holiday data
 Code cleanup
 
 ## v1.2.6

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -18,7 +18,6 @@
                 </field>
                 <field id="key" translate="label comment" type="obscure" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>API Key</label>
-                    <comment>Optional. Used for tracking and/or to increase usage limits.</comment>
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                 </field>
             </group>


### PR DESCRIPTION
Fixes #15 

Google geocoding response now returns a status of `"OK"`, rather than the previous `200`.
Additionally, ensure that functions in GoogleMapsGeocodeResult return correct types.