### PR TITLE
Fix gallery pagebuilder attribute

### DIFF
--- a/view/adminhtml/layout/stockists_index_edit.xml
+++ b/view/adminhtml/layout/stockists_index_edit.xml
@@ -6,6 +6,7 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="admin-2columns-left"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <update handle="editor"/>
     <body>
         <referenceContainer name="content">
             <uiComponent name="stockist_form"/>


### PR DESCRIPTION
The paegbuilder attribute `gallery` doesn't work out of the box by configuring the `stockist_form.xml` file with wysiwyg settings.

The admin layout page must also include an additional `update` to reference the editor handle.

**Steps to reproduce**
When using pagebuilder to customise the Gallery data, you can click the "edit with pagebuilder" button, and drag/drop empty components into place. However once in the pagebuilder editor page the settings cog for each element does not respond.