### PR TITLE
Fix future pagebuilder attributes (can't edit pagebuilder components)

### DIFF
--- a/view/adminhtml/layout/stockists_index_edit.xml
+++ b/view/adminhtml/layout/stockists_index_edit.xml
@@ -9,6 +9,7 @@
     <head>
         <link src="Aligent_Stockists::js/validate-json.js"/>
     </head>
+    <update handle="editor"/>
     <body>
         <referenceContainer name="content">
             <uiComponent name="stockist_form"/>


### PR DESCRIPTION
As discussed in [issue](https://github.com/aligent/magento-stockists-module/issues/18) and [pull request](https://github.com/aligent/magento-stockists-module/pull/19), these changes will future proof the stockist module, allowing for pagebuilder attributes to work by simply changing the `stockist_form.xml` configurations.