### PR TITLE
Add geocoding API region biasing control

### DIFF
--- a/Controller/Adminhtml/Index/Save.php
+++ b/Controller/Adminhtml/Index/Save.php
@@ -99,7 +99,7 @@ class Save extends Action implements HttpPostActionInterface
 
         } catch (\Exception $e) {
             $this->messageManager->addErrorMessage($e->getMessage());
-            $resultRedirect->setPath('*/*/new');
+            $resultRedirect->setPath('*/*');
         }
 
         return $resultRedirect;

--- a/Controller/Adminhtml/Index/Save.php
+++ b/Controller/Adminhtml/Index/Save.php
@@ -72,6 +72,12 @@ class Save extends Action implements HttpPostActionInterface
         try {
             $requestData = $this->getRequestData();
             $stockist = $this->stockistFactory->create();
+
+            $stockistId = $requestData[StockistInterface::STOCKIST_ID];
+            if (!empty($stockistId)) {
+                $stockist = $this->stockistRepository->getById((int)$stockistId);
+            }
+
             $this->processSave($stockist, $requestData);
             $this->messageManager->addSuccessMessage('Stockist has been saved');
             if ($this->getRequest()->getParam('redirect_to_new')) {

--- a/Model/GoogleMapsAdapter.php
+++ b/Model/GoogleMapsAdapter.php
@@ -98,7 +98,7 @@ class GoogleMapsAdapter implements AdapterInterface
 
         $queryParams = [
             'address' => $address,
-            'key' => $key,
+            'key' => $key
         ];
 
         // Restrict the address results to a specific area if Geocoding API's Region Biasing is enabled

--- a/Model/GoogleMapsAdapter.php
+++ b/Model/GoogleMapsAdapter.php
@@ -6,13 +6,18 @@ use Aligent\Stockists\Api\AdapterInterface;
 use Aligent\Stockists\Api\Data\StockistInterface;
 use Aligent\Stockists\Api\GeocodeResultInterface;
 use Aligent\Stockists\Api\GeocodeResultInterfaceFactory;
+use Aligent\Stockists\Api\StockistRepositoryInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\HTTP\Client\CurlFactory;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Framework\Url\QueryParamsResolverInterface;
+use Magento\Store\Model\ScopeInterface;
 
 class GoogleMapsAdapter implements AdapterInterface
 {
     const PATH= 'https://maps.googleapis.com/maps/api/geocode/';
+
+    const XML_PATH_ENABLE_API_BIASING = 'stockists/geocode/enable_api_biaisng';
 
     const OUTPUT_FORMAT = 'json';
 
@@ -36,28 +41,53 @@ class GoogleMapsAdapter implements AdapterInterface
      */
     private $geocodeResultFactory;
 
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
+     * @var StockistRepositoryInterface
+     */
+    private $stockistRepository;
+
     public function __construct(
         CurlFactory $httpClientFactory,
         QueryParamsResolverInterface $queryParamsResolver,
         Json $serialiser,
-        GeocodeResultInterfaceFactory $geocodeResultFactory
+        GeocodeResultInterfaceFactory $geocodeResultFactory,
+        ScopeConfigInterface $scopeConfig,
+        StockistRepositoryInterface $stockistRepository
     ) {
         $this->httpClientFactory = $httpClientFactory;
         $this->queryParamsResolver = $queryParamsResolver;
         $this->serialiser = $serialiser;
         $this->geocodeResultFactory = $geocodeResultFactory;
+        $this->scopeConfig = $scopeConfig;
+        $this->stockistRepository = $stockistRepository;
     }
 
     public function addressHasChangedFor($stockist): bool
     {
+        if (!$stockist->getStockistId()) {
+            return true;
+        }
+
+        $stockistOrig = $this->stockistRepository->getById($stockist->getStockistId());
+
         foreach (['street', 'city', 'region', 'country'] as $field) {
-            if ($stockist->dataHasChangedFor($field)) {
+            $newData = $stockist->getData($field);
+            $previousData = $stockistOrig->getData($field);
+
+            if ($newData != $previousData) {
                 return true;
             }
         }
 
         return false;
     }
+
+
 
     /**
      * @inheritDoc
@@ -68,8 +98,17 @@ class GoogleMapsAdapter implements AdapterInterface
 
         $queryParams = [
             'address' => $address,
-            'key' => $key
+            'key' => $key,
         ];
+
+        // Restrict the address results to a specific area if Geocoding API's Region Biasing is enabled
+        if ($this->isApiBiasingEnabled()) {
+            $queryParams['region'] = $stockist->getCountry();
+
+            $components = $this->buildComponents($stockist);
+            $queryParams['components'] = $components;
+
+        }
 
         $query = $this->queryParamsResolver->addQueryParams($queryParams)->getQuery();
 
@@ -90,6 +129,20 @@ class GoogleMapsAdapter implements AdapterInterface
         ];
 
         return implode(',', $params);
+    }
+
+    /**
+     * @param Stockist $stockist
+     * @return string
+     */
+    protected function buildComponents(Stockist $stockist): string
+    {
+        $params = [
+            'country:' . $stockist->getCountry(),
+            'postal_code:' . $stockist->getPostcode(),
+        ];
+
+        return implode('|', $params);
     }
 
     /**
@@ -129,5 +182,15 @@ class GoogleMapsAdapter implements AdapterInterface
         }
 
         return $result;
+    }
+
+    /**
+     * Check config value of stockists/geocode/enable_api_biaisng
+     *
+     * @return bool
+     */
+    protected function isApiBiasingEnabled()
+    {
+        return $this->scopeConfig->isSetFlag(self::XML_PATH_ENABLE_API_BIASING, ScopeInterface::SCOPE_STORE);
     }
 }

--- a/Model/OptionSource/GeocodingResquestSource.php
+++ b/Model/OptionSource/GeocodingResquestSource.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+namespace Aligent\Stockists\Model\OptionSource;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+/**
+ * Provide option values for UI
+ *
+ * @api
+ */
+class GeocodingResquestSource implements OptionSourceInterface
+{
+
+    /**
+     * Constants for Geocoding Request option values
+     */
+    public const DEFAULT  = 'default';
+    public const REGION_BIASING  = 'region';
+    public const COMPONENT_FILTERING  = 'component';
+
+    /**
+     * @inheritDoc
+     */
+    public function toOptionArray(): array
+    {
+        return [
+            [
+                'value' => self::DEFAULT,
+                'label' => __('Default')
+            ],
+            [
+                'value' => self::REGION_BIASING,
+                'label' => __('Region Biasing')
+            ],
+            [
+                'value' => self::COMPONENT_FILTERING,
+                'label' => __('Component Filtering')
+            ]
+        ];
+    }
+}

--- a/Model/ResourceModel/Stockist.php
+++ b/Model/ResourceModel/Stockist.php
@@ -60,9 +60,10 @@ class Stockist extends AbstractDb
         $storeIds = $object->getData(StockistInterface::STORE_IDS) ?? [0];
         $object->setData(StockistInterface::STORE_IDS, implode(',', $storeIds));
 
-        $openingHours = $object->getData(StockistInterface::HOURS) ? $object->getData(StockistInterface::HOURS)->getData() : null;
-        if (is_array($openingHours)) {
-            $object->setData(StockistInterface::HOURS, $this->json->serialize($openingHours));
+        $openingHours = $object->getData(StockistInterface::HOURS) ?? null;
+        if ($openingHours && is_array($openingHours->getData())) {
+            $hoursData = $openingHours->getData();
+            $object->setData(StockistInterface::HOURS, $this->json->serialize($hoursData));
         }
         return parent::_beforeSave($object);
     }

--- a/Model/ResourceModel/Stockist.php
+++ b/Model/ResourceModel/Stockist.php
@@ -60,7 +60,7 @@ class Stockist extends AbstractDb
         $storeIds = $object->getData(StockistInterface::STORE_IDS) ?? [0];
         $object->setData(StockistInterface::STORE_IDS, implode(',', $storeIds));
 
-        $openingHours = $object->getData(StockistInterface::HOURS) ?? null;
+        $openingHours = $object->getData(StockistInterface::HOURS) ? $object->getData(StockistInterface::HOURS)->getData() : null;
         if (is_array($openingHours)) {
             $object->setData(StockistInterface::HOURS, $this->json->serialize($openingHours));
         }

--- a/Model/Stockist/DataProcessor/Coordinate.php
+++ b/Model/Stockist/DataProcessor/Coordinate.php
@@ -17,11 +17,16 @@ class Coordinate implements StockistDataProcessorInterface
      */
     public function execute(array $data): array
     {
+        if (!isset($data[StockistInterface::LNG]) || !isset($data[StockistInterface::LAT])) {
+            return $data;
+        }
+
         if (empty($data[StockistInterface::LNG]) || empty($data[StockistInterface::LAT])) {
             // fetch by address
             $data[StockistInterface::LNG] = 0.0;
             $data[StockistInterface::LAT] = 0.0;
         }
+
         return $data;
     }
 }

--- a/Model/Stockist/DataProcessor/TradingHours.php
+++ b/Model/Stockist/DataProcessor/TradingHours.php
@@ -43,11 +43,13 @@ class TradingHours implements StockistDataProcessorInterface
      */
     public function execute(array $data): array
     {
-        $tradingHours = $this->tradingHoursFactory->create();
-        $tradingHoursData = $data[StockistInterface::HOURS] ?
+        if (isset($data[StockistInterface::HOURS])) {
+            $tradingHours = $this->tradingHoursFactory->create();
+            $tradingHoursData = $data[StockistInterface::HOURS] ?
             $this->json->unserialize($data[StockistInterface::HOURS]) : "{}";
-        $tradingHours->setData($tradingHoursData);
-        $data[StockistInterface::HOURS] = $tradingHours;
+            $tradingHours->setData($tradingHoursData);
+            $data[StockistInterface::HOURS] = $tradingHours;
+        }
         return $data;
     }
 }

--- a/Model/Stockist/DataProcessor/TradingHours.php
+++ b/Model/Stockist/DataProcessor/TradingHours.php
@@ -46,7 +46,7 @@ class TradingHours implements StockistDataProcessorInterface
         if (isset($data[StockistInterface::HOURS])) {
             $tradingHours = $this->tradingHoursFactory->create();
             $tradingHoursData = $data[StockistInterface::HOURS] ?
-            $this->json->unserialize($data[StockistInterface::HOURS]) : "{}";
+                $this->json->unserialize($data[StockistInterface::HOURS]) : "{}";
             $tradingHours->setData($tradingHoursData);
             $data[StockistInterface::HOURS] = $tradingHours;
         }

--- a/Model/Stockist/Hydrator.php
+++ b/Model/Stockist/Hydrator.php
@@ -106,13 +106,15 @@ class Hydrator implements HydratorInterface
         if (empty($data[StockistInterface::STOCKIST_ID])) {
             unset($data[StockistInterface::STOCKIST_ID]);
         }
-        $data[StockistInterface::IS_ACTIVE] = (bool)$data[StockistInterface::IS_ACTIVE];
+
+        if (isset($data[StockistInterface::IS_ACTIVE])) {
+            $data[StockistInterface::IS_ACTIVE] = (bool)$data[StockistInterface::IS_ACTIVE];
+        }
 
         if (isset($data[StockistInterface::COUNTRY_ID])) {
             $data[StockistInterface::COUNTRY] = $data[StockistInterface::COUNTRY_ID];
         }
 
-        $data[StockistInterface::REGION] = "";
         if (!empty($data[StockistInterface::REGION_ID])) {
             $region = $this->regionFactory->create();
             $this->regionResource->load($region, $data[StockistInterface::REGION_ID], 'region_id');

--- a/Model/StockistRepository.php
+++ b/Model/StockistRepository.php
@@ -152,7 +152,7 @@ class StockistRepository implements StockistRepositoryInterface
                 __('Invalid stockist data: %1', implode(',', $validationErrors))
             );
         } else {
-            if ($stockist->getStockistId()) {
+            if ($stockist->getIdentifier() && $stockist->getStockistId()) {
                 $existingStockist = $this->get($stockist->getIdentifier());
                 $stockist->setStockistId($existingStockist->getId());
             }

--- a/Model/StockistRepository.php
+++ b/Model/StockistRepository.php
@@ -137,6 +137,7 @@ class StockistRepository implements StockistRepositoryInterface
      * @return StockistInterface
      * @throws AlreadyExistsException
      * @throws CouldNotSaveException
+     * @throws NoSuchEntityException
      */
     public function save(StockistInterface $stockist): StockistInterface
     {
@@ -151,11 +152,9 @@ class StockistRepository implements StockistRepositoryInterface
                 __('Invalid stockist data: %1', implode(',', $validationErrors))
             );
         } else {
-            try {
+            if ($stockist->getStockistId()) {
                 $existingStockist = $this->get($stockist->getIdentifier());
                 $stockist->setStockistId($existingStockist->getId());
-            } catch (NoSuchEntityException $e) {
-                throw new CouldNotSaveException(__('Stockist with ID %1 does not exist', $stockist->getIdentifier()));
             }
             $this->stockistResource->save($stockist);
         }

--- a/Service/GeocodeStockist.php
+++ b/Service/GeocodeStockist.php
@@ -20,8 +20,6 @@ class GeocodeStockist implements GeocodeStockistInterface
 {
     const XML_PATH_GEOCODE_KEY = 'stockists/geocode/key';
 
-    const XML_PATH_ENABLE_API_BIASING = 'stockists/geocode/enable_api_biaisng';
-
     /**
      * @var AdapterInterface
      */
@@ -57,11 +55,6 @@ class GeocodeStockist implements GeocodeStockistInterface
                 return;
             }
 
-            // Return if Geocoding API's Region Biasing is not enabled
-            if (!$this->isApiBiasingEnabled()) {
-                return;
-            }
-
             $request = $this->adapter->buildRequest($stockist, $key);
             $response = $this->adapter->performGeocode($request);
             $result = $this->adapter->handleResponse($response);
@@ -73,21 +66,8 @@ class GeocodeStockist implements GeocodeStockistInterface
         }
     }
 
-    /**
-     * @return mixed
-     */
     protected function getGeocodeKey()
     {
         return $this->scopeConfig->getValue(self::XML_PATH_GEOCODE_KEY, ScopeInterface::SCOPE_STORE);
-    }
-
-    /**
-     * Check config value of stockists/geocode/enable_api_biaisng
-     *
-     * @return bool
-     */
-    protected function isApiBiasingEnabled()
-    {
-        return (bool)$this->scopeConfig->getValue(self::XML_PATH_ENABLE_API_BIASING, ScopeInterface::SCOPE_STORE);
     }
 }

--- a/Service/GeocodeStockist.php
+++ b/Service/GeocodeStockist.php
@@ -20,6 +20,8 @@ class GeocodeStockist implements GeocodeStockistInterface
 {
     const XML_PATH_GEOCODE_KEY = 'stockists/geocode/key';
 
+    const XML_PATH_ENABLE_API_BIASING = 'stockists/geocode/enable_api_biaisng';
+
     /**
      * @var AdapterInterface
      */
@@ -55,6 +57,11 @@ class GeocodeStockist implements GeocodeStockistInterface
                 return;
             }
 
+            // Return if Geocoding API's Region Biasing is not enabled
+            if (!$this->isApiBiasingEnabled()) {
+                return;
+            }
+
             $request = $this->adapter->buildRequest($stockist, $key);
             $response = $this->adapter->performGeocode($request);
             $result = $this->adapter->handleResponse($response);
@@ -66,8 +73,21 @@ class GeocodeStockist implements GeocodeStockistInterface
         }
     }
 
+    /**
+     * @return mixed
+     */
     protected function getGeocodeKey()
     {
         return $this->scopeConfig->getValue(self::XML_PATH_GEOCODE_KEY, ScopeInterface::SCOPE_STORE);
+    }
+
+    /**
+     * Check config value of stockists/geocode/enable_api_biaisng
+     *
+     * @return bool
+     */
+    protected function isApiBiasingEnabled()
+    {
+        return (bool)$this->scopeConfig->getValue(self::XML_PATH_ENABLE_API_BIASING, ScopeInterface::SCOPE_STORE);
     }
 }

--- a/Ui/DataProvider/Stockist.php
+++ b/Ui/DataProvider/Stockist.php
@@ -97,10 +97,15 @@ class Stockist extends DataProvider
             $item[StockistInterface::HOURS] = $this->json->serialize($item[StockistInterface::HOURS]);
             $item[StockistInterface::STORE_IDS] = implode(',', $item[StockistInterface::STORE_IDS]);
             $item[StockistInterface::COUNTRY_ID] = $item[StockistInterface::COUNTRY];
-            $item[StockistInterface::REGION_ID] = $this->regionFactory->create()->loadByName(
-                $item[StockistInterface::REGION],
-                $item[StockistInterface::COUNTRY_ID],
-            )->getRegionId();
+
+            // Some countries have no regions (e.g. NZ)
+            if (!empty($item[StockistInterface::REGION])) {
+                $item[StockistInterface::REGION_ID] = $this->regionFactory->create()->loadByName(
+                    $item[StockistInterface::REGION],
+                    $item[StockistInterface::COUNTRY_ID],
+                )->getRegionId();
+            }
+
             $item[StockistInterface::IS_ACTIVE] = (bool)$item[StockistInterface::IS_ACTIVE];
 
             // Make sure extension attributes are copied onto the item itself, then we can

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -23,6 +23,7 @@
                 <field id="enable_api_biaisng" translate="label comment" type="select" sortOrder="35" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable Geocoding API's Region Biasing</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment><![CDATA[The Geocoding API returns address results biased to the given country and postcode. <a href=https://developers.google.com/maps/documentation/geocoding/requests-geocoding#RegionCodes">Click here</a> for more details.]]></comment>
                 </field>
             </group>
         </section>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -20,6 +20,10 @@
                     <label>API Key</label>
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                 </field>
+                <field id="enable_api_biaisng" translate="label comment" type="select" sortOrder="35" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Enable Geocoding API's Region Biasing</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
             </group>
         </section>
     </system>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -20,10 +20,11 @@
                     <label>API Key</label>
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                 </field>
-                <field id="enable_api_biaisng" translate="label comment" type="select" sortOrder="35" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Enable Geocoding API's Region Biasing</label>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <comment><![CDATA[The Geocoding API returns address results biased to the given country and postcode. <a href=https://developers.google.com/maps/documentation/geocoding/requests-geocoding#RegionCodes">Click here</a> for more details.]]></comment>
+                <field id="request_option" translate="label comment" type="select" sortOrder="35" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Geocoding Request Options</label>
+                    <source_model>Aligent\Stockists\Model\OptionSource\GeocodingResquestSource</source_model>
+                    <comment><![CDATA[The Geocoding API supports <a href=https://developers.google.com/maps/documentation/geocoding/requests-geocoding#RegionCodes">Region Biasing</a>, which returns address results that are biased towards the given country. It
+                   also has the ability to restrict the address results based on the given country and postcode using <a href="https://developers.google.com/maps/documentation/geocoding/requests-geocoding#component-filtering">Component filtering</a>.]]></comment>
                 </field>
             </group>
         </section>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -6,6 +6,7 @@
             <geocode>
                 <url>https://maps.googleapis.com/maps/api/geocode/</url>
                 <key backend_model="Magento\Config\Model\Config\Backend\Encrypted"/>
+                <enable_api_biaisng>0</enable_api_biaisng>
             </geocode>
         </stockists>
     </default>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -6,7 +6,7 @@
             <geocode>
                 <url>https://maps.googleapis.com/maps/api/geocode/</url>
                 <key backend_model="Magento\Config\Model\Config\Backend\Encrypted"/>
-                <enable_api_biaisng>0</enable_api_biaisng>
+                <request_option>default</request_option>
             </geocode>
         </stockists>
     </default>


### PR DESCRIPTION
Adds an admin area toggle to decide whether or not to use the region biasing feature from the Google geocoding service

Ticket in the back-end board: https://aligent.atlassian.net/browse/BEG-82
Linked issue : https://github.com/aligent/magento-stockists-module/issues/24

