### PR TITLE
fix: remove null constraint on URL key

### DIFF
--- a/Model/ResourceModel/Stockist.php
+++ b/Model/ResourceModel/Stockist.php
@@ -104,6 +104,8 @@ class Stockist extends AbstractDb
         $storeIds = (string)$object->getData(StockistModel::STORE_IDS);
         if ($storeIds !== '') {
             $object->setData(StockistModel::STORE_IDS, explode(',', $storeIds));
+        } else {
+            $object->setData(StockistModel::STORE_IDS, []);
         }
         return parent::_afterLoad($object);
     }

--- a/Model/ResourceModel/Stockist.php
+++ b/Model/ResourceModel/Stockist.php
@@ -102,7 +102,7 @@ class Stockist extends AbstractDb
         }
 
         $storeIds = $object->getData(StockistModel::STORE_IDS);
-        if ($storeIds) {
+        if (!empty($storeIds) || $storeIds === '0') {
             $object->setData(StockistModel::STORE_IDS, explode(',', $storeIds));
         }
         return parent::_afterLoad($object);

--- a/Model/ResourceModel/Stockist.php
+++ b/Model/ResourceModel/Stockist.php
@@ -101,8 +101,8 @@ class Stockist extends AbstractDb
             $object->setData(StockistModel::HOURS, $tradingHours);
         }
 
-        $storeIds = $object->getData(StockistModel::STORE_IDS);
-        if (!empty($storeIds) || $storeIds === '0') {
+        $storeIds = (string)$object->getData(StockistModel::STORE_IDS);
+        if ($storeIds !== '') {
             $object->setData(StockistModel::STORE_IDS, explode(',', $storeIds));
         }
         return parent::_afterLoad($object);

--- a/Model/Stockist.php
+++ b/Model/Stockist.php
@@ -118,7 +118,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function getUrlKey(): string
     {
-        return $this->getData(StockistInterface::URL_KEY);
+        return $this->getData(StockistInterface::URL_KEY) ?? '';
     }
 
     /**

--- a/Ui/DataProvider/Stockist.php
+++ b/Ui/DataProvider/Stockist.php
@@ -105,9 +105,9 @@ class Stockist extends \Magento\Framework\View\Element\UiComponent\DataProvider\
             // For details see \Magento\Ui\Component\Form::getDataSourceData
             if ($data['totalRecords'] > 0) {
                 $stockistId = $data['items'][0][\Aligent\Stockists\Api\Data\StockistInterface::STOCKIST_ID];
-                $stockistGenenalData = $data['items'][0];
+                $stockistGeneralData = $data['items'][0];
                 $dataForSingle[$stockistId] = [
-                    'general' => $stockistGenenalData,
+                    'general' => $stockistGeneralData,
                 ];
                 return $dataForSingle;
             }

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -5,7 +5,7 @@
         <column name="stockist_id" xsi:type="int" padding="10" unsigned="true" nullable="false" identity="true" comment="Entity ID"/>
         <column name="identifier" xsi:type="varchar" nullable="false" comment="External identifier" />
         <column name="is_active" xsi:type="boolean" nullable="false" comment="Store is currently active" default="true"/>
-        <column name="url_key" xsi:type="varchar" nullable="false" comment="Url Key"/>
+        <column name="url_key" xsi:type="varchar" nullable="true" comment="Url Key"/>
         <column name="lat" xsi:type="decimal" scale="6" precision="9" nullable="true" comment="Latitude" />
         <column name="lng" xsi:type="decimal" scale="6" precision="9" nullable="true" comment="Longitude" />
         <column name="name" xsi:type="varchar" comment="Name" />


### PR DESCRIPTION
Working through the stockist upgrade for a client, these are the issues that I have discovered cause problems. These are not necessarily the best solutions, but grouping these changes together so we can work through them.

I think the `getStoreIds` function experiencing some intermittent data structures is interesting and must be caused by something else in the code base changing the structure from a string to an array. It changes structure between load and save for some reason.

In terms of the db schema change for url key, If a client was using the stockist module prior to 1.2.5.0 when the url_key DB field did not exist, and attempts to update the stockist module through to 1.2.6 the setup:upgrade fails as the unique index on url_key fails.

We need to consider whether a dataPatch or setup patch when upgrading to 1.2.6 is required to populate a bunch of default url_keys based on the identifier or name? Alternatively we can leave this as nullable, and I think this will leave the validator function to block save requests until a url_key is provided.

```
SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '' for key 'STOCKIST_URL_KEY', query was: ALTER TABLE `stockist` ADD COLUMN `is_active` BOOLEAN NOT NULL DEFAULT 1 COMMENT "Store is currently active", ADD COLUMN `url_key` varchar(255) NOT NULL  COMMENT "Url Key", ADD COLUMN `description` text NULL COMMENT "Description", ADD COLUMN `gallery` text NULL COMMENT "Gallery", ADD COLUMN `suburb` varchar(255) NULL  COMMENT "Suburb", ADD COLUMN `allow_store_delivery` BOOLEAN NULL DEFAULT 0 COMMENT "Allow Store for Delivery", ADD CONSTRAINT `STOCKIST_URL_KEY` UNIQUE KEY (`url_key`)
```