### PR TITLE
fix: Let handleTradingHours accept default store_id of string 0 (falsey)

### DIFF
--- a/Model/ResourceModel/Stockist.php
+++ b/Model/ResourceModel/Stockist.php
@@ -71,23 +71,27 @@ class Stockist extends AbstractDb
     /**
      * Once the JSON-encoded hours data has been persisted by save(), re-hydrate the model with the
      * array structure
+     * Also convert csv string to array for store_ids
      * @param AbstractModel $object
      * @return AbstractDb
      */
     protected function _afterSave(AbstractModel $object): AbstractDb
     {
         $this->handleTradingHours($object);
+        $this->handleStoreIds($object);
         return parent::_afterSave($object);
     }
 
     /**
      * When loading a stockist model, unserialize the JSON-encoded opening hours into it's array form
+     * Also convert csv string to array for store_ids
      * @param AbstractModel $object
      * @return AbstractDb
      */
     protected function _afterLoad(AbstractModel $object): AbstractDb
     {
         $this->handleTradingHours($object);
+        $this->handleStoreIds($object);
         return parent::_afterLoad($object);
     }
 
@@ -107,6 +111,12 @@ class Stockist extends AbstractDb
         }
     }
 
+    /**
+     * @param AbstractModel $object
+     * @return void
+     */
+    private function handleStoreIds(AbstractModel $object): void
+    {
         $storeIds = (string)$object->getData(StockistInterface::STORE_IDS);
         if ($storeIds !== '') {
             $object->setData(StockistInterface::STORE_IDS, explode(',', $storeIds));

--- a/Model/ResourceModel/Stockist.php
+++ b/Model/ResourceModel/Stockist.php
@@ -105,10 +105,13 @@ class Stockist extends AbstractDb
             $tradingHours->setData($unserializedHours);
             $object->setData(StockistInterface::HOURS, $tradingHours);
         }
+    }
 
-        $storeIds = $object->getData(StockistInterface::STORE_IDS);
-        if ($storeIds) {
+        $storeIds = (string)$object->getData(StockistInterface::STORE_IDS);
+        if ($storeIds !== '') {
             $object->setData(StockistInterface::STORE_IDS, explode(',', $storeIds));
+        } else {
+            $object->setData(StockistInterface::STORE_IDS, []);
         }
     }
 }


### PR DESCRIPTION
As discussed in the [PR to `develop-1.x`](https://github.com/aligent/magento-stockists-module/pull/26/files), if no store_ids are set or from a previous implementation, or the default store_id is set, the logic in `handleTradingHours` does not set an array and `getStoreIds` throws an error.

The other changes from my PR to `develop-1.x` are up for debate as to whether you wish to include them. I've updated `db_schema.xml` in client project to set `url_key` to nullable, 2.X also allows for the null return type in the getter.