### PR TITLE
Fix/prevent internal error on stockist update request

### DIFF
--- a/Model/StockistRepository.php
+++ b/Model/StockistRepository.php
@@ -152,9 +152,17 @@ class StockistRepository implements StockistRepositoryInterface
                 __('Invalid stockist data: %1', implode(',', $validationErrors))
             );
         } else {
-            if ($stockist->getIdentifier() && $stockist->getStockistId()) {
-                $existingStockist = $this->get($stockist->getIdentifier());
-                $stockist->setStockistId($existingStockist->getId());
+            try {
+                if ($stockist->getStockistId()) {
+                    $existingStockist = $this->getById($stockist->getStockistId());
+                    $stockist->setStockistId($existingStockist->getId());
+                } elseif ($stockist->getIdentifier()) {
+                    $existingStockist = $this->get($stockist->getIdentifier());
+                    $stockist->setStockistId($existingStockist->getId());
+                }
+            } catch (NoSuchEntityException $e) {
+                // Want to check whether the stockist exists in an attempt to update an existing one before
+                // saving a new one. If it doesn't exist there is no need to do anything here.
             }
             $this->stockistResource->save($stockist);
         }

--- a/Model/StockistRepository.php
+++ b/Model/StockistRepository.php
@@ -141,10 +141,6 @@ class StockistRepository implements StockistRepositoryInterface
      */
     public function save(StockistInterface $stockist): StockistInterface
     {
-        // New non-nullable field which might not be considered in older API
-        if ($stockist->getIsActive() === null) {
-            $stockist->setIsActive(true);
-        }
         $validationErrors = $this->stockistValidation->validate($stockist);
 
         if (!empty($validationErrors)) {
@@ -159,6 +155,12 @@ class StockistRepository implements StockistRepositoryInterface
                 } elseif ($stockist->getIdentifier()) {
                     $existingStockist = $this->get($stockist->getIdentifier());
                     $stockist->setStockistId($existingStockist->getId());
+                } else {
+                    // New non-nullable field which might not be considered in older API
+                    // Only set this if it's a new stockist and not found above
+                    if ($stockist->getIsActive() === null) {
+                        $stockist->setIsActive(true);
+                    }
                 }
             } catch (NoSuchEntityException $e) {
                 // Want to check whether the stockist exists in an attempt to update an existing one before


### PR DESCRIPTION
If the API request to create/update a stockist doesn't have both the stockist_id and the identifier it will always attempt to create a new stockist, and will hit an SQL integrity error because of the unique constraint on identifier.

This pull request:
- Makes more attempts at finding the existing stockist to update it
- Avoids the risk of setting `is_active` on an existing disabled stockist