### PR TITLE
fix: Make createSearchCriteria a public function

### DIFF
--- a/Model/Resolver/Stockists.php
+++ b/Model/Resolver/Stockists.php
@@ -88,7 +88,7 @@ class Stockists implements ResolverInterface
      * @param array $args
      * @return GeoSearchCriteriaInterface
      */
-    private function createSearchCriteria(array $args): GeoSearchCriteriaInterface
+    public function createSearchCriteria(array $args): GeoSearchCriteriaInterface
     {
         $radius = $args['location']['radius'];
         $units = $args['location']['unit'];


### PR DESCRIPTION
This method was made private during the version 2 upgrade, but did not account for existing projects having plugin methods on this function.