### PR TITLE
Resolved get identities cache tag default value

### DIFF
--- a/Model/Stockist.php
+++ b/Model/Stockist.php
@@ -27,7 +27,7 @@ class Stockist extends AbstractExtensibleModel implements StockistInterface, Ide
      */
     public function getIdentities(): array
     {
-        return [self::CACHE_TAG . '_' . $this->getId()];
+        return [self::CACHE_TAG . '_' . $this->getId() ?? ''];
     }
 
     /**


### PR DESCRIPTION
Resolved get identities cache tag default value since it is possible to return null for getId()

On RAG, recently we found the below error when the user tried to place a click-and-collect order.

`[2023-03-08T00:03:47.993919+00:00] report.ERROR: Aligent\Stockists\Model\Stockist::getIdentifier(): Return value must be of type string, null returned`

![image-20230308-002941](https://user-images.githubusercontent.com/66452547/223901928-2f79debf-8b6d-477f-8c26-eca4becf3423.png)

PR code changes will make sure that if the stockist ID is not found default cache tag value will be returned.