### PR TITLE
BEG-207 | fix: correct boolean conversion for is_active field in Hydr…

### DIFF
--- a/Model/Stockist/Hydrator.php
+++ b/Model/Stockist/Hydrator.php
@@ -108,7 +108,7 @@ class Hydrator implements HydratorInterface
         }
 
         if (isset($data[StockistInterface::IS_ACTIVE])) {
-            $data[StockistInterface::IS_ACTIVE] = (bool)$data[StockistInterface::IS_ACTIVE];
+            $data[StockistInterface::IS_ACTIVE] = $data[StockistInterface::IS_ACTIVE] === 'true';
         }
 
         if (isset($data[StockistInterface::COUNTRY_ID])) {


### PR DESCRIPTION
\Aligent\Stockists\Model\Stockist\Hydrator::hydrate

(bool)$data[StockistInterface::IS_ACTIVE] returns true when is set to 'false'
Due to how PHP's boolean casting. is_active